### PR TITLE
fix: backend build and run with profiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       CORS_ALLOWED_ORIGINS: https://silentguard-local.ricardocampos.dev.br:5173
       TARGET_ENV: development
       API_LOGGING_LEVEL: INFO
+      SPRING_PROFILES_ACTIVE: dev
     ports:
       - "8443:8443"
       - "5005:5005"

--- a/silent-api/Dockerfile
+++ b/silent-api/Dockerfile
@@ -8,7 +8,7 @@ COPY src ./src
 COPY .mvn/ ./.mvn
 
 # Build
-RUN ./mvnw -B package -Pnative -DskipTests
+RUN ./mvnw -B package -Pnative -DskipTests -Dspring.profiles.active=prod
 
 ### Deployer
 FROM debian:12.11-slim AS deploy

--- a/silent-api/src/main/resources/application-dev.properties
+++ b/silent-api/src/main/resources/application-dev.properties
@@ -1,12 +1,11 @@
 server.port=8443
-server.ssl.enabled=false
+server.ssl.enabled=true
 server.ssl.key-store=classpath:certs/keystore.p12
 server.ssl.key-store-type=PKCS12
 server.ssl.key-store-password=changeit
 server.ssl.key-alias=silentguard-local
 server.error.include-message=always
 spring.application.name=silent-guard-api
-spring.profiles.active=@spring.profiles.active@
 
 # Auth0 configuration
 spring.security.oauth2.resourceserver.jwt.issuer-uri = ${AUTH_DOMAIN:http://localhost}


### PR DESCRIPTION
# What

- application.properties file with dev and default profiles

# Why

- Run prod and dev profiles accordingly to the environment settings

# Mood

<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
