### PR TITLE
fix: api port

### DIFF
--- a/silent-api/src/main/resources/application.properties
+++ b/silent-api/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-server.port=8443
+server.port=8080
 server.ssl.enabled=false
 server.ssl.key-store=classpath:certs/keystore.p12
 server.ssl.key-store-type=PKCS12


### PR DESCRIPTION
# What

- Application properties default file

# Why

- When copying from dev it got the wrong port (8443 instead of 8080)

# Mood

<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img width="200" src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOWdwM2ZnYWpqMWt5d2oxaXMwaDFmY2RyNmNpYXRyM2U1ZHZpem4zZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3JQD7ydPwFuGjBQNre/giphy.gif"/>